### PR TITLE
Improve RFC 6585 compliance

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -136,7 +136,7 @@ template = {
         {"name": "Redirects", "description": "Returns different redirect responses"},
         {
             "name": "Rate limiting",
-            "description": "Test client-side rate limiting with Retry-After headers",
+            "description": "Test client-side rate limiting with 429 responses and optional Retry-After headers",
         },
         {
             "name": "Anything",
@@ -779,6 +779,26 @@ def view_status_code(codes):
     code = weighted_choice(choices)
 
     return status_code(code)
+
+
+@app.route(
+    "/too-many-requests", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "TRACE"]
+)
+def response_retry_after():
+    """Return 429 status code with no Retry-After header
+    ---
+    tags:
+      - Rate limiting
+    produces:
+      - text/plain
+    responses:
+      429:
+        description: Too Many Requests
+    """
+    response = make_response()
+    response.status_code = 429
+
+    return response
 
 
 @app.route(

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -812,13 +812,19 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(parse_multi_value_header('"xyzzy", "r2d2xxxx", "c3piozzzz"'), [ "xyzzy", "r2d2xxxx", "c3piozzzz" ])
         self.assertEqual(parse_multi_value_header('W/"xyzzy", W/"r2d2xxxx", W/"c3piozzzz"'), [ "xyzzy", "r2d2xxxx", "c3piozzzz" ])
         self.assertEqual(parse_multi_value_header('*'), [ "*" ])
+        
+    def test_too_many_requests(self):
+        response = self.app.get('/too-many-requests')
+        self.assertEqual(response.status_code, 429)
 
     def test_retry_after_seconds(self):
         response = self.app.get('/retry-after/seconds/60')
+        self.assertEqual(response.status_code, 429)
         self.assertEqual(response.headers.get('Retry-After'), '60')
 
     def test_retry_after_date(self):
         response = self.app.get('/retry-after/date/60')
+        self.assertEqual(response.status_code, 429)
         # difficult to test the actual response, but we can at least test that it is a parseable date
         self.assertTrue(time.strptime(response.headers.get('Retry-After'), "%a, %d %b %Y %H:%M:%S GMT"))
 


### PR DESCRIPTION
* Retry-After headers are a MAY; httpbin can now return a 429 response with no Retry-After
* improved the unit tests to make sure the status code is actually 429 for the rate limiting endpoints